### PR TITLE
fix the font size of the text in the contact section

### DIFF
--- a/dark/assets/css/styles.css
+++ b/dark/assets/css/styles.css
@@ -1037,7 +1037,7 @@ html {
   font-family: "Kanit", sans-serif;
   font-weight: bolder;
   color: rgb(122, 122, 122);
-  font-size: 24px;
+  font-size: 18px;
 }
 
 #contact-section h3 {


### PR DESCRIPTION
I changed the font size of the `contact-text` in the contact section.

Below are screenshots of how it looks after:

`AFTER`:

<img width="1440" alt="Screen Shot 2022-11-01 at 12 31 03" src="https://user-images.githubusercontent.com/94648837/199223950-5127c72d-399f-40d6-b8c9-9d667a660919.png">
