### PR TITLE
Change the old twitter logo to the new one from Icons8

### DIFF
--- a/dark/index.html
+++ b/dark/index.html
@@ -147,7 +147,7 @@
       </div>
       <div id="tooltip">
         <span id="tooltiptext">Twitter</span>
-        <a href="https://twitter.com/Yoshitha2008" target="_blank "><img src="https://img.icons8.com/color/48/000000/twitter-circled--v1.png" alt="Twitter Icon" /></a>
+        <a href="https://twitter.com/Yoshitha2008" target="_blank "><img src="https://img.icons8.com/?size=48&id=YfCbGWCWcuar&format=png&color=ffffff" alt="Twitter Icon" /></a>
       </div>
       <div id="tooltip">
         <span id="tooltiptext">LinkedIn</span>


### PR DESCRIPTION
## Purpose
Fixes Issue #223 

## Goals
Change the old Twitter icon to the newer icon (X) logo

## Approach
Get a PNG URL from Icons8 with the X logo and set the color and size to white (ffffff) and 48 respectively.

### Screenshots
Before change
![Screenshot_20241006_200000](https://github.com/user-attachments/assets/c01eb5d1-dc18-433a-b727-353a945ea79a)


After change
![Screenshot_20241006_194229](https://github.com/user-attachments/assets/6a4c63e5-3bec-495f-a5a2-abbcbfd8aa93)